### PR TITLE
Implement multi-stage builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # nrf51822dk base image
 # See more about resin base images here: http://docs.resin.io/runtime/resin-base-images/
-FROM resin/nrf51822dk
+FROM resin/nrf51822dk AS buildstep
 
 # Set the working directory
 WORKDIR /usr/src/app
@@ -17,3 +17,9 @@ COPY source/ ./source
 # Compile the firmware
 RUN make && \
 	nrfutil dfu genpkg --application _build/nrf51422_xxac_s130.hex /assets/application.zip
+
+# Start with a minimal runtime container
+FROM alpine
+
+# Copy the compiled firmware into the empty runtime container
+COPY --from=buildstep /assets/application.zip /assets/application.zip


### PR DESCRIPTION
Implement multi-stage builds, reducing the final container size down to less than 4MB